### PR TITLE
fix build with musl

### DIFF
--- a/attr.c
+++ b/attr.c
@@ -25,6 +25,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/base.c
+++ b/base.c
@@ -25,6 +25,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/helper.c
+++ b/helper.c
@@ -25,6 +25,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <regex.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
limits.h header is missing in attr.c, base.c and helper.c to provide
PATH_MAX.

Fixes:
http://autobuild.buildroot.net/results/702/7023104e6018ea46c54073ddbe5119d0f66ae5a3

Signed-off-by: Romain Naour <romain.naour@smile.fr>

[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/libuio/0002-fix-build-with-musl.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>