### PR TITLE
Allow uio device nodes with no maps

### DIFF
--- a/helper.c
+++ b/helper.c
@@ -311,15 +311,7 @@ struct uio_info_t *create_uio_info (char *dir, char *name)
 
 	snprintf (filename, PATH_MAX, "%s/%s/maps", dir, name);
 	info->maps = scan_maps (filename, &info->maxmap);
-	if(info->maps == NULL)
-	{
-		free(info->path);
-		free(info->name);
-		free(info->version);
-		free(info->devname);
-		free(info);
-		return NULL;
-	}
+
 	info->fd = -1;
 
 	return info;


### PR DESCRIPTION
Revert to previous behavior which allows uio device nodes with no
memory maps.  This is useful for devices which have multiple interrupt
requests.  The first uio device specifies the memory map and the first
interrupt line.  Subsequent uio devcies without map entries may then be
used to specify additional interrupts.

Signed-off-by: Charles Steinkuehler <cstein@newtek.com>