### PR TITLE
configure: remove po/Makefile.in

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,5 +55,4 @@ dnl last but not least
 AC_OUTPUT([Makefile
 	libuio.dox
 	libuio-uninstalled.pc
-	libuio.pc
-	po/Makefile.in])
+	libuio.pc])


### PR DESCRIPTION
The file po/Makefile.in is automatically added to AC_OUTPUT while using gettexize

Signed-off-by: Romain Naour <romain.naour@smile.fr>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/libuio/0001-configure-remove-po-Makefile.in.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>