### PR TITLE
Fix formatting output

### DIFF
--- a/attr.c
+++ b/attr.c
@@ -67,6 +67,9 @@ char **uio_list_attr (struct uio_info_t* info)
 	nr = scandir (path, &namelist, 0, alphasort);
 	if (nr < 0)
 	{
+		if (ENOENT == errno){
+			return NULL;
+		}
 		g_warning (_("scandir: %s"), g_strerror (errno));
 		return NULL;
 	}

--- a/lsuio.c
+++ b/lsuio.c
@@ -112,7 +112,6 @@ int main (int argc, char **argv)
 					uio_get_offset (info, i));
 			}
 		}
-		g_print (_("\n"));
 
 		g_print (_("Attr.  :\n"));
 		attr = uio_list_attr (info);
@@ -142,6 +141,7 @@ int main (int argc, char **argv)
 			else
 				g_print (_("failed\n"));
 		}
+		g_print (_("\n"));
 	}
 
 	free (uio_list);


### PR DESCRIPTION
-Add scandir error check to avoid excess warnings
-Fix formatting for lsuio output of new line

Before:
![image](https://user-images.githubusercontent.com/74835766/100012471-f5f9cd80-2d98-11eb-9ee1-ec71cb1e19b6.png)

After:
![image](https://user-images.githubusercontent.com/74835766/100012790-76203300-2d99-11eb-84a0-9aadae4e85ae.png)