### PR TITLE
Some changes to fix memory leaks

### DIFF
--- a/base.c
+++ b/base.c
@@ -279,7 +279,7 @@ struct uio_info_t *uio_find_by_uio_name (char *uio_name)
 		if (!strcmp (name, uio_name)) {
 			info = candidate;
 		} else {
-			free(candidate);
+			uio_free_info(candidate);
 		}
 	}
 	/* If we found a match, all but the matching one should be freed. If no

--- a/base.c
+++ b/base.c
@@ -22,7 +22,6 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#include <assert.h>
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -213,7 +212,6 @@ struct uio_info_t **uio_find_devices ()
 	int i, t = 0, nr;
 
 	snprintf (sysfsname, sizeof (sysfsname), "%s/class/uio", sysfs);
-	/* This includes the two directories . and .. */
 	nr = scandir (sysfsname, &namelist, 0, alphasort);
 	if (nr < 0)
 	{
@@ -236,12 +234,6 @@ struct uio_info_t **uio_find_devices ()
 
 		info [t++] = create_uio_info (sysfsname, namelist [i]->d_name);
 	}
-	/* 
-	 * Because . and .. should have been in the original result which was
-	 * used to calculate the length to allocate, we are guaranteed that the
-	 * array will be NULL terminated.
-	 */
-	assert(info[nr - 1] == NULL);
 
 out:
 	for (i = 0; i < nr; i++)
@@ -268,29 +260,18 @@ struct uio_info_t *uio_find_by_uio_name (char *uio_name)
 	if (!uio_list)
 		return NULL;
 
-	/* 
-	 * Iterating over the elements returned from uio_find_devices() assumes
-	 * that either a match is found or the NULL sentinel is reached.
-	 */
 	for (list = uio_list; *list; list++)
 	{
 		struct uio_info_t *candidate = *list;
 
 		name = uio_get_name (candidate);
 
-		/* 
-		 * Free every entry in the result from uio_find_devices() except
-		 * the one that matches
-		 */
 		if (!strcmp (name, uio_name)) {
 			info = candidate;
 		} else {
 			uio_free_info(candidate);
 		}
 	}
-	/* If we found a match, all but the matching one should be freed. If no
-	 * match, then the entire result should be freed. In either case, we can
-	 * free the result from uio_find_devices() */
 	free (uio_list);
 
 	return info;

--- a/base.c
+++ b/base.c
@@ -187,8 +187,14 @@ void uio_free_info(struct uio_info_t* info)
 			free (info->name);
 		if (info->version)
 			free (info->version);
-		if (info->maps)
-			free (info->maps);
+		if (info->maps) {
+			for (int i = 0; i < info->maxmap; i++) {
+				if (info->maps[i].name) {
+					free(info->maps[i].name);
+				}
+			}
+			free(info->maps);
+		}
 		if (info->devname)
 			free (info->devname);
 		free (info);
@@ -235,7 +241,7 @@ struct uio_info_t **uio_find_devices ()
 	 * used to calculate the length to allocate, we are guaranteed that the
 	 * array will be NULL terminated.
 	 */
-	assert(info[nr] == NULL);
+	assert(info[nr - 1] == NULL);
 
 out:
 	for (i = 0; i < nr; i++)

--- a/base.c
+++ b/base.c
@@ -22,6 +22,7 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
+#include <assert.h>
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -206,6 +207,7 @@ struct uio_info_t **uio_find_devices ()
 	int i, t = 0, nr;
 
 	snprintf (sysfsname, sizeof (sysfsname), "%s/class/uio", sysfs);
+	/* This includes the two directories . and .. */
 	nr = scandir (sysfsname, &namelist, 0, alphasort);
 	if (nr < 0)
 	{
@@ -216,7 +218,6 @@ struct uio_info_t **uio_find_devices ()
 	info = calloc (nr, sizeof (struct uio_info_t *));
 	if (!info)
 	{
-		errno = ENOMEM;
 		g_warning (_("calloc: %s\n"), g_strerror (errno));
 		goto out;
 	}
@@ -229,6 +230,12 @@ struct uio_info_t **uio_find_devices ()
 
 		info [t++] = create_uio_info (sysfsname, namelist [i]->d_name);
 	}
+	/* 
+	 * Because . and .. should have been in the original result which was
+	 * used to calculate the length to allocate, we are guaranteed that the
+	 * array will be NULL terminated.
+	 */
+	assert(info[nr] == NULL);
 
 out:
 	for (i = 0; i < nr; i++)
@@ -255,17 +262,29 @@ struct uio_info_t *uio_find_by_uio_name (char *uio_name)
 	if (!uio_list)
 		return NULL;
 
+	/* 
+	 * Iterating over the elements returned from uio_find_devices() assumes
+	 * that either a match is found or the NULL sentinel is reached.
+	 */
 	for (list = uio_list; *list; list++)
 	{
 		struct uio_info_t *candidate = *list;
 
 		name = uio_get_name (candidate);
 
+		/* 
+		 * Free every entry in the result from uio_find_devices() except
+		 * the one that matches
+		 */
 		if (!strcmp (name, uio_name)) {
 			info = candidate;
-			break;
+		} else {
+			free(candidate);
 		}
 	}
+	/* If we found a match, all but the matching one should be freed. If no
+	 * match, then the entire result should be freed. In either case, we can
+	 * free the result from uio_find_devices() */
 	free (uio_list);
 
 	return info;

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl Every other copy of the package version number gets its value from here
-AC_INIT(libuio, 0.2.8, https://github.com/linutronix/libuio/issues)
+AC_INIT(libuio, 0.3.0, https://github.com/missinglinkelectronics/libuio/issues)
 AM_INIT_AUTOMAKE
 
 AM_CONFIG_HEADER(config.h)

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl Every other copy of the package version number gets its value from here
-AC_INIT(libuio, 0.3.0, https://github.com/missinglinkelectronics/libuio/issues)
+AC_INIT(libuio, 0.2.8, https://github.com/linutronix/libuio/issues)
 AM_INIT_AUTOMAKE
 
 AM_CONFIG_HEADER(config.h)

--- a/helper.c
+++ b/helper.c
@@ -293,8 +293,10 @@ struct uio_info_t *create_uio_info (char *dir, char *name)
 	char filename [PATH_MAX];
 
 	info = calloc (1, sizeof (struct uio_info_t));
-	if (!info)
+	if (!info) {
+		g_warning (_("calloc: %s\n"), g_strerror (errno));
 		return NULL;
+	}
 
 	snprintf (filename, PATH_MAX, "%s/%s", dir, name);
 	info->path = strdup (filename);

--- a/libuio.h
+++ b/libuio.h
@@ -35,6 +35,7 @@ extern "C" {
 struct uio_info_t;
 
 /* base functions */
+void uio_free_info(struct uio_info_t* info);
 struct uio_info_t **uio_find_devices ();
 struct uio_info_t *uio_find_by_uio_name (char *uio_name);
 struct uio_info_t *uio_find_by_uio_num (int num);


### PR DESCRIPTION
The `uio_free_info` function wasn't freeing memory allocated for memory maps.  The array returned by `uio_find_devices` was also not being freed entirely.  Added a missing function declaration that was noticed during compilation.