### PR TITLE
Fix offset within page calculation

### DIFF
--- a/helper.c
+++ b/helper.c
@@ -178,7 +178,18 @@ static struct uio_map_t *scan_maps (char *dir, int *maxmap)
 		tmp = first_line_from_file (name);
 		map [t].size = strtoul (tmp, NULL, 0);
 		free (tmp);
-		map [t].offset = map [t].addr & (getpagesize () - 1);
+
+		tmp = first_line_from_file (name);
+		offset = 0;
+		if (tmp)
+		{
+			offset = strtoul (tmp, NULL, 0);
+			free (tmp);
+		}
+		if (offset == 0)
+			offset = map [t].addr & (getpagesize () - 1);
+		map [t].offset = offset;
+
 		map [t].map = MAP_FAILED;
 
 		*maxmap = ++t;


### PR DESCRIPTION
In Linux kernel since commit https://github.com/torvalds/linux/commit/e2b39df119712ea5184562a6a14696a5cea8ef18 property "offset" is exported, but it was just `mem->addr & ~PAGE_MASK` until commit https://github.com/torvalds/linux/commit/171058fb0883247b3a484a542b5dc89753c57cb5 when `addr` became "rounded to page size" and `offset` became a field of `struct uio_mem`. But in uio_pdrv_genirq until commit https://github.com/torvalds/linux/commit/7aca462b133300c16213e214bb96e516f1f2784e `addr` wasn't rounded by page size and field `offset` wasn't even initialized. Memory to struct where uio_mem is allocated by kzalloc so offset was 0.

In this commit `offset` calculated as `addr & (getpagesize () - 1)` if: 
1) file "offset" doesn't exist
2) 0 was read from file "offset"